### PR TITLE
Branch training impact reach

### DIFF
--- a/models/intermediate/_no_registration.yml
+++ b/models/intermediate/_no_registration.yml
@@ -44,3 +44,6 @@ models:
       - name: participant_category
         data_type: text
         description: Category of the participant in the course.
+      - name: training_indirect_reach_monthly
+        data_type: integer
+        description: Monthly indirect reach through training.

--- a/models/intermediate/_participant_impact.yml
+++ b/models/intermediate/_participant_impact.yml
@@ -151,9 +151,12 @@ models:
       - name: relation_with_child
         data_type: character varying
         description: Relation with the child
-      - name: reg_non_working_month
+      - name: working_with_people_devdelay_montly
         data_type: character varying
-        description: Registered non-working month
+        description: How many of these people or their families experience developmental disabilities (monthly figures)
+      - name: training_indirect_reach_monthly
+        data_type: integer
+        description: Monthly indirect reach through training
       - name: child_birth_date_info1
         data_type: character varying
         description: Child birth date information 1

--- a/models/intermediate/appointment_data.sql
+++ b/models/intermediate/appointment_data.sql
@@ -15,7 +15,7 @@ WITH appointment_data AS(
     NULLIF(createdby, '') AS created_by,
     --NULLIF(consultant, '')::VARCHAR AS doctor,
     -- Cleaned doctor name value by removing titles, salutations and extra spaces
-    -- The regex removes common titles like Dr., Miss, Ms., Mr., and Mister
+    -- The regex removes common titles like Dr., Miss, Ms., Mr., Mrs., and Mister
     NULLIF(
         REGEXP_REPLACE(
             REGEXP_REPLACE(

--- a/models/intermediate/appointment_data.sql
+++ b/models/intermediate/appointment_data.sql
@@ -20,7 +20,7 @@ WITH appointment_data AS(
         REGEXP_REPLACE(
             REGEXP_REPLACE(
                 TRIM(
-                    REGEXP_REPLACE(COALESCE(consultant, ''), '(?i)(^|\s)(dr\.?|miss|ms\.?|mr\.?|mister)(\s|$)', ' ')
+                    REGEXP_REPLACE(COALESCE(consultant, ''), '(?i)(^|\s)(dr\.?|miss|ms\.?|mr\.?|mister|mrs\.?)(\s|$)', ' ')
                 ),
                 '\s+', ' '
             ),

--- a/models/intermediate/clinic_data.sql
+++ b/models/intermediate/clinic_data.sql
@@ -13,15 +13,14 @@ WITH clinic_data AS (
         -- Cleaned doctor name value by removing titles, salutations and extra spaces
         -- The regex removes common titles like Dr., Miss, Ms., Mr., and Mister
         REGEXP_REPLACE(
-                REGEXP_REPLACE(
-                    TRIM(
-                        REGEXP_REPLACE(doctor, '(?i)(^|\s)(dr\.?|miss|ms\.?|mr\.?|mister)(\s|$)', ' ')
-                    ),
-                    '\s+', ' '
+            REGEXP_REPLACE(
+                TRIM(
+                    REGEXP_REPLACE(doctor, '(?i)(^|\s)(dr\.?|miss|ms\.?|mr\.?|mister|mrs\.?)(\s|$)', ' ')
                 ),
-                '^\s+|\s+$', ''
-            )::VARCHAR AS doctor,
-
+                '\s+', ' '
+            ),
+            '^\s+|\s+$', ''
+        )::VARCHAR AS doctor,
         TO_DATE(consultationrequestdate, 'DD-MON-YY') AS consultation_date,
         REPLACE(appointmenttype,'?', '-') AS consultation_type,
         unit,

--- a/models/intermediate/clinic_data.sql
+++ b/models/intermediate/clinic_data.sql
@@ -11,7 +11,7 @@ WITH clinic_data AS (
         department::VARCHAR AS department,
         --doctor::VARCHAR AS doctor,
         -- Cleaned doctor name value by removing titles, salutations and extra spaces
-        -- The regex removes common titles like Dr., Miss, Ms., Mr., and Mister
+        -- The regex removes common titles like Dr., Miss, Ms., Mr., Mrs., and Mister
         REGEXP_REPLACE(
             REGEXP_REPLACE(
                 TRIM(

--- a/models/intermediate/no_registration.sql
+++ b/models/intermediate/no_registration.sql
@@ -25,6 +25,8 @@ SELECT
     sd."programShortName" AS program_short_name,
     jsonb_extract_path_text(content.value, 'totalcount')::INTEGER AS total_count,
     jsonb_extract_path_text(content.value, 'participantCount')::INTEGER AS participant_count,
-    jsonb_extract_path_text(content.value, 'participantCategory') AS participant_category
+    jsonb_extract_path_text(content.value, 'participantCategory') AS participant_category,
+    -- 0 integer value is to ensure that schema remains consistent for total_participant_disagg because indirect reach is calculated for registered participants
+    0 AS training_indirect_reach_monthly
 FROM source_data AS sd,
     LATERAL jsonb_array_elements(sd."unregisteredCount"->'content') AS content

--- a/models/intermediate/participant_impact.sql
+++ b/models/intermediate/participant_impact.sql
@@ -47,7 +47,25 @@ SELECT
     "programShortName" AS program_short_name,
     "secondaryContact" AS secondary_contact,
     "relationWithChild" AS relation_with_child,
-    "regNonWorkingMonth" AS reg_non_working_month,
+    "regNonWorkingMonth" AS working_with_people_devdelay_montly,
+    CASE
+        WHEN LOWER("regNonWorkingMonth") = 'none' THEN 0
+
+        WHEN LOWER("regNonWorkingMonth") LIKE 'greater than %' THEN 
+            CAST(
+                REGEXP_REPLACE(LOWER("regNonWorkingMonth"), '^greater than\s+(\d+).*$', '\1')
+                AS INTEGER
+            )
+
+        WHEN "regNonWorkingMonth" LIKE '%-%' THEN ROUND(
+            (
+                CAST(LTRIM(SPLIT_PART(TRIM("regNonWorkingMonth"), '-', 1), '0') AS INTEGER) +
+                CAST(LTRIM(SPLIT_PART(TRIM("regNonWorkingMonth"), '-', 2), '0') AS INTEGER)
+            ) / 2.0
+        )::INTEGER
+
+        ELSE 0
+    END::INTEGER AS training_indirect_reach_monthly,
     "childBirthDateinfo1" AS child_birth_date_info1,
     "childBirthDateinfo2" AS child_birth_date_info2,
     "childBirthDateinfo3" AS child_birth_date_info3,

--- a/models/prod/_tms_training_master.yml
+++ b/models/prod/_tms_training_master.yml
@@ -41,6 +41,12 @@ models:
       - name: reg_attending_program
         data_type: character varying
         description: Registration status for attending the program
+      - name: reg_non_working_month
+        data_type: character varying
+        description: How many of these people or their families experience developmental disabilities (monthly figures)
+      - name: training_indirect_reach_monthly
+        data_type: integer
+        description: Monthly indirect reach through training
       - name: start_date
         data_tests:
           - dbt_expectations.expect_column_values_to_be_of_type:

--- a/models/prod/_total_participants_disagg.yml
+++ b/models/prod/_total_participants_disagg.yml
@@ -36,6 +36,9 @@ models:
       - name: pid
         data_type: character varying
         description: Unique identifier for the participant.
+      - name: training_indirect_reach_monthly
+        data_type: integer
+        description: Monthly indirect reach through training
       - name: source
         data_type: text
         description: Indicates the origin or source of the participant data.

--- a/models/prod/tms_training_master.sql
+++ b/models/prod/tms_training_master.sql
@@ -14,6 +14,25 @@ SELECT
     p.course_short_name,
     p.organisation_name,
     COALESCE(p.reg_attending_program, 'Not Available') AS reg_attending_program,
+    p.reg_non_working_month, 
+    CASE
+        WHEN LOWER("reg_non_working_month") = 'none' THEN 0
+
+        WHEN LOWER("reg_non_working_month") LIKE 'greater than %' THEN 
+            CAST(
+                REGEXP_REPLACE(LOWER("reg_non_working_month"), '^greater than\s+(\d+).*$', '\1')
+                AS INTEGER
+            )
+
+        WHEN "reg_non_working_month" LIKE '%-%' THEN ROUND(
+            (
+                CAST(LTRIM(SPLIT_PART(TRIM("reg_non_working_month"), '-', 1), '0') AS INTEGER) +
+                CAST(LTRIM(SPLIT_PART(TRIM("reg_non_working_month"), '-', 2), '0') AS INTEGER)
+            ) / 2.0
+        )::INTEGER
+
+        ELSE 0
+    END::INTEGER AS training_indirect_reach_monthly,
     p.start_date,
     EXTRACT(YEAR FROM p.start_date) AS year,
     

--- a/models/prod/total_participants_disagg.sql
+++ b/models/prod/total_participants_disagg.sql
@@ -13,6 +13,7 @@ WITH participant_impact_clean AS (
         program_short_name,
         COALESCE(reg_attending_program, 'Not Available') AS participant_category,
         pid,
+        training_indirect_reach_monthly,
         'participant_impact' AS source,
 
         -- Calculate Financial Year
@@ -57,8 +58,8 @@ no_registrations_expanded AS (
         participant_category,
         -- Generate a unique `pid` for each missing participant, ensuring it's a string
         CONCAT('nr_', LPAD((ROW_NUMBER() OVER ())::TEXT, 6, '0')) AS pid,
+        0 AS training_indirect_reach_monthly,
         'no_registrations' AS source,
-
         -- Calculate Financial Year
         CASE 
             WHEN EXTRACT(MONTH FROM TO_DATE(start_date_str, 'DD/MM/YYYY')) >= 4 

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -499,7 +499,7 @@ sources:
             description: Name of the organisation
           - name: regMonthWorking
             data_type: character varying
-            description: Month of registration for working individuals
+            description: Approximately how many individual children/young people/families do you work with monthly                 
           - name: takeCareOfChild
             data_type: character varying
             description: Indicates if the participant takes care of a child
@@ -526,7 +526,7 @@ sources:
             description: Relation with the child
           - name: regNonWorkingMonth
             data_type: character varying
-            description: Month of registration for non-working individuals
+            description: How many of these people or their families experience developmental disabilities (monthly figures)
           - name: childBirthDateinfo1
             data_type: character varying
             description: Birth date of child 1


### PR DESCRIPTION
The 'training_indirect_reach_monthly' column has been created to calculate the number of children indirectly impacted by the training sessions provided by Ummeed. 

And also, a modification is made to the logic of cleaning doctor name values (removes common titles like Dr., Miss, Ms., Mr., Mrs., and Mister).