### PR TITLE
Repaired the column name error in tms_training_master

### DIFF
--- a/models/prod/tms_training_master.sql
+++ b/models/prod/tms_training_master.sql
@@ -14,20 +14,20 @@ SELECT
     p.course_short_name,
     p.organisation_name,
     COALESCE(p.reg_attending_program, 'Not Available') AS reg_attending_program,
-    p.reg_non_working_month, 
+    p.working_with_people_devdelay_montly, 
     CASE
-        WHEN LOWER("reg_non_working_month") = 'none' THEN 0
+        WHEN LOWER("working_with_people_devdelay_montly") = 'none' THEN 0
 
-        WHEN LOWER("reg_non_working_month") LIKE 'greater than %' THEN 
+        WHEN LOWER("working_with_people_devdelay_montly") LIKE 'greater than %' THEN 
             CAST(
-                REGEXP_REPLACE(LOWER("reg_non_working_month"), '^greater than\s+(\d+).*$', '\1')
+                REGEXP_REPLACE(LOWER("working_with_people_devdelay_montly"), '^greater than\s+(\d+).*$', '\1')
                 AS INTEGER
             )
 
-        WHEN "reg_non_working_month" LIKE '%-%' THEN ROUND(
+        WHEN "working_with_people_devdelay_montly" LIKE '%-%' THEN ROUND(
             (
-                CAST(LTRIM(SPLIT_PART(TRIM("reg_non_working_month"), '-', 1), '0') AS INTEGER) +
-                CAST(LTRIM(SPLIT_PART(TRIM("reg_non_working_month"), '-', 2), '0') AS INTEGER)
+                CAST(LTRIM(SPLIT_PART(TRIM("working_with_people_devdelay_montly"), '-', 1), '0') AS INTEGER) +
+                CAST(LTRIM(SPLIT_PART(TRIM("working_with_people_devdelay_montly"), '-', 2), '0') AS INTEGER)
             ) / 2.0
         )::INTEGER
 


### PR DESCRIPTION
Fixed the column used to calculate training_indirect_reach_monthly in tms_training_master. Sorry that I did not consider the changed name of column "regNonWorkingMonth" AS "working_with_people_devdelay_montly" in intermediate.participant_impact.