### PR TITLE
Modified the logic for determining calculated age and age group.

### DIFF
--- a/models/intermediate/_clinic_data.yml
+++ b/models/intermediate/_clinic_data.yml
@@ -103,7 +103,7 @@ models:
         description: Fiscal year end date based on date of birth and consultation date
       - name: calculated_age
         data_type: text
-        description: Calculated age based on date of birth
+        description: Calculated age based on date of birth and fiscal year end date
       - name: age_group
         data_type: text
         description: Age group classification

--- a/models/intermediate/_clinic_data.yml
+++ b/models/intermediate/_clinic_data.yml
@@ -98,6 +98,9 @@ models:
       - name: registered_mobile_no
         data_type: character varying
         description: Mobile number of the registered patient
+      - name: fiscal_year_end_date
+        data_type: date
+        description: Fiscal year end date based on date of birth and consultation date
       - name: calculated_age
         data_type: text
         description: Calculated age based on date of birth

--- a/models/intermediate/clinic_data.sql
+++ b/models/intermediate/clinic_data.sql
@@ -81,108 +81,129 @@ registered_patient AS (
         registration_type,
         service_center_name
     FROM {{ ref('registered_patient') }}
+),
+BASE_CLINIC_DATA AS (
+    SELECT 
+        cd.*,
+        rp.registered_patient_id,
+        rp.registered_patient_age,
+        rp.date_of_birth,
+        rp.registered_patient_gender,
+        rp.diagnosis,
+        rp.registered_mobile_no::VARCHAR AS registered_mobile_no,
+        CASE
+            WHEN rp.date_of_birth IS NOT NULL AND cd.consultation_date IS NOT NULL THEN
+                CASE
+                    WHEN TO_DATE(rp.date_of_birth, 'DD/MM/YYYY') < cd.consultation_date THEN
+                        -- Use consultation_date
+                        CASE
+                            WHEN EXTRACT(MONTH FROM cd.consultation_date) >= 4 THEN
+                                CONCAT('31/03/', EXTRACT(YEAR FROM cd.consultation_date) + 1)
+                            ELSE
+                                CONCAT('31/03/', EXTRACT(YEAR FROM cd.consultation_date))
+                        END
+                    WHEN EXTRACT(YEAR FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')) = EXTRACT(YEAR FROM cd.consultation_date) THEN
+                        -- Same year: use max month
+                        CASE
+                            WHEN GREATEST(EXTRACT(MONTH FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')), EXTRACT(MONTH FROM cd.consultation_date)) > 4 THEN
+                                CONCAT('31/03/', EXTRACT(YEAR FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')) + 1)
+                            ELSE
+                                CONCAT('31/03/', EXTRACT(YEAR FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')))
+                        END
+                    ELSE
+                        -- Different years: use later date
+                        CASE
+                            WHEN EXTRACT(MONTH FROM 
+                                CASE 
+                                    WHEN EXTRACT(YEAR FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')) > EXTRACT(YEAR FROM cd.consultation_date) 
+                                    THEN TO_DATE(rp.date_of_birth, 'DD/MM/YYYY') 
+                                    ELSE cd.consultation_date 
+                                END
+                            ) > 4 THEN
+                                CONCAT('31/03/', GREATEST(EXTRACT(YEAR FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')), EXTRACT(YEAR FROM cd.consultation_date)) + 1)
+                            ELSE
+                                CONCAT('31/03/', GREATEST(EXTRACT(YEAR FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')), EXTRACT(YEAR FROM cd.consultation_date)))
+                        END
+                END
+            ELSE NULL
+        END AS fiscal_year_end_date,    
+        rp.parent_guardian_phone,
+        rp.parent_guardian_age,
+        rp.parent_guardian_city,
+        rp.parent_guardian_district,
+        rp.parent_guardian_state,
+        rp.parent_guardian_country,
+        rp.who_brought_the_child,
+        CASE 
+            WHEN
+                LOWER(rp.parent_guardian_city) = 'mumbai' 
+                OR LOWER(rp.parent_guardian_district) = 'mumbai' 
+                OR (
+                    LOWER(rp.parent_guardian_state) = 'maharashtra' 
+                    AND LOWER(rp.parent_guardian_country) = 'india'
+                )
+                THEN 'Mumbai'
+            ELSE 'Non-Mumbai'
+        END AS location_category,
+        rp.pat_idn_no,
+        rp.guardian_pin,
+        rp.plan_name,
+        rp.is_processed,
+        rp.updated_date,
+        rp.inserted_date,
+        rp.identity_type,
+        rp.patient_income,
+        rp.registration_type,
+        rp.service_center_name,
+        ctm."New Classification" AS consultation_category,  -- Mapped from dim_consultation_type_mapping
+        CONCAT_WS(' ', dda.acronym, ctm."New Classification") AS dep_consult_category,  -- Acronym + Consultation Category
+        dda.acronym AS dep_shortened,
+        ddlm.doctor_level AS doctor_level  -- Mapped from dim_doctor_level_mapping
+
+    FROM clinic_data AS cd
+    LEFT JOIN registered_patient AS rp
+        ON cd.mrno = rp.mrno
+    LEFT JOIN {{ source('source_ummeed_ict_health', 'dim_consultation_type_mapping') }} AS ctm
+        ON cd.consultation_type = ctm."Consultation Type"
+    LEFT JOIN {{ source('source_ummeed_ict_health', 'dim_department_acronym') }} AS dda
+        ON cd.department = dda.department
+    LEFT JOIN {{ source('source_ummeed_ict_health', 'dim_doctor_level_mapping') }} AS ddlm
+        ON cd.doctor = ddlm.doctor
 )
 
 SELECT 
-    cd.*,
-    rp.registered_patient_id,
-    rp.registered_patient_age,
-    rp.date_of_birth,
-    rp.registered_patient_gender,
-    rp.diagnosis,
-    rp.registered_mobile_no::VARCHAR AS registered_mobile_no,
+    *,
+    DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date, 'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY')))::TEXT AS calculated_age,
+
     CASE
-        WHEN rp.date_of_birth IS NOT NULL AND cd.consultation_date IS NOT NULL THEN
-            CASE
-                WHEN TO_DATE(rp.date_of_birth, 'DD/MM/YYYY') < cd.consultation_date THEN
-                    -- Use consultation_date
-                    CASE
-                        WHEN EXTRACT(MONTH FROM cd.consultation_date) >= 4 THEN
-                            CONCAT('31/03/', EXTRACT(YEAR FROM cd.consultation_date) + 1)
-                        ELSE
-                            CONCAT('31/03/', EXTRACT(YEAR FROM cd.consultation_date))
-                    END
-                WHEN EXTRACT(YEAR FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')) = EXTRACT(YEAR FROM cd.consultation_date) THEN
-                    -- Same year: use max month
-                    CASE
-                        WHEN GREATEST(EXTRACT(MONTH FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')), EXTRACT(MONTH FROM cd.consultation_date)) > 4 THEN
-                            CONCAT('31/03/', EXTRACT(YEAR FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')) + 1)
-                        ELSE
-                            CONCAT('31/03/', EXTRACT(YEAR FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')))
-                    END
-                ELSE
-                    -- Different years: use later date
-                    CASE
-                        WHEN EXTRACT(MONTH FROM 
-                            CASE 
-                                WHEN EXTRACT(YEAR FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')) > EXTRACT(YEAR FROM cd.consultation_date) 
-                                THEN TO_DATE(rp.date_of_birth, 'DD/MM/YYYY') 
-                                ELSE cd.consultation_date 
-                            END
-                        ) > 4 THEN
-                            CONCAT('31/03/', GREATEST(EXTRACT(YEAR FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')), EXTRACT(YEAR FROM cd.consultation_date)) + 1)
-                        ELSE
-                            CONCAT('31/03/', GREATEST(EXTRACT(YEAR FROM TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')), EXTRACT(YEAR FROM cd.consultation_date)))
-                    END
-            END
-        ELSE NULL
-    END::DATE AS fiscal_year_end_date,    
-    DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY')))::TEXT AS calculated_age,
-    CASE
-        WHEN rp.date_of_birth IS NULL OR fiscal_year_end_date IS NULL THEN NULL
+        WHEN bcd.date_of_birth IS NULL OR bcd.fiscal_year_end_date IS NULL THEN NULL
         ELSE
             CASE
-                WHEN DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) < 2 
-                THEN 'Group A: 0 ≤ age < 2'
-                WHEN DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) >= 2 AND DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) < 4 THEN 'Group B: 2 ≤ age < 4'
-                WHEN DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) >= 4 AND DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) < 6 THEN 'Group C: 4 ≤ age < 6'
-                WHEN DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) >= 6 AND DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) < 10 THEN 'Group D: 6 ≤ age < 10'
-                WHEN DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) >= 10 AND DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) < 12 THEN 'Group E: 10 ≤ age < 12'
-                WHEN DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) >= 12 AND DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) < 14 THEN 'Group F: 12 ≤ age < 14'
-                WHEN DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) >= 14 AND DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) < 16 THEN 'Group G: 14 ≤ age < 16'
-                WHEN DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) >= 16 AND DATE_PART('year', AGE(TO_DATE(fiscal_year_end_date), TO_DATE(rp.date_of_birth, 'DD/MM/YYYY'))) < 18 THEN 'Group H: 16 ≤ age < 18'
+                WHEN DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) < 2 
+                    THEN 'Group A: 0 ≤ age < 2'
+                WHEN DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) >= 2 
+                    AND DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) < 4 
+                    THEN 'Group B: 2 ≤ age < 4'
+                WHEN DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) >= 4 
+                    AND DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) < 6 
+                    THEN 'Group C: 4 ≤ age < 6'
+                WHEN DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) >= 6 
+                    AND DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) < 10 
+                    THEN 'Group D: 6 ≤ age < 10'
+                WHEN DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) >= 10 
+                    AND DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) < 12 
+                    THEN 'Group E: 10 ≤ age < 12'
+                WHEN DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) >= 12 
+                    AND DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) < 14 
+                    THEN 'Group F: 12 ≤ age < 14'
+                WHEN DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) >= 14 
+                    AND DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) < 16 
+                    THEN 'Group G: 14 ≤ age < 16'
+                WHEN DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) >= 16 
+                    AND DATE_PART('year', AGE(TO_DATE(bcd.fiscal_year_end_date,'DD/MM/YYYY'), TO_DATE(bcd.date_of_birth, 'DD/MM/YYYY'))) < 18 
+                    THEN 'Group H: 16 ≤ age < 18'
                 ELSE 'Group I: 18 and above'
             END
-    END AS age_group,
-    rp.parent_guardian_phone,
-    rp.parent_guardian_age,
-    rp.parent_guardian_city,
-    rp.parent_guardian_district,
-    rp.parent_guardian_state,
-    rp.parent_guardian_country,
-    rp.who_brought_the_child,
-    CASE 
-        WHEN
-            LOWER(rp.parent_guardian_city) = 'mumbai' 
-            OR LOWER(rp.parent_guardian_district) = 'mumbai' 
-            OR (
-                LOWER(rp.parent_guardian_state) = 'maharashtra' 
-                AND LOWER(rp.parent_guardian_country) = 'india'
-            )
-            THEN 'Mumbai'
-        ELSE 'Non-Mumbai'
-    END AS location_category,
-    rp.pat_idn_no,
-    rp.guardian_pin,
-    rp.plan_name,
-    rp.is_processed,
-    rp.updated_date,
-    rp.inserted_date,
-    rp.identity_type,
-    rp.patient_income,
-    rp.registration_type,
-    rp.service_center_name,
-    ctm."New Classification" AS consultation_category,  -- Mapped from dim_consultation_type_mapping
-    CONCAT_WS(' ', dda.acronym, ctm."New Classification") AS dep_consult_category,  -- Acronym + Consultation Category
-    dda.acronym AS dep_shortened,
-    ddlm.doctor_level AS doctor_level  -- Mapped from dim_doctor_level_mapping
+    END AS age_group
 
-FROM clinic_data AS cd
-LEFT JOIN registered_patient AS rp
-    ON cd.mrno = rp.mrno
-LEFT JOIN {{ source('source_ummeed_ict_health', 'dim_consultation_type_mapping') }} AS ctm
-    ON cd.consultation_type = ctm."Consultation Type"
-LEFT JOIN {{ source('source_ummeed_ict_health', 'dim_department_acronym') }} AS dda
-    ON cd.department = dda.department
-LEFT JOIN {{ source('source_ummeed_ict_health', 'dim_doctor_level_mapping') }} AS ddlm
-    ON cd.doctor = ddlm.doctor
+FROM BASE_CLINIC_DATA as bcd

--- a/models/prod/_cancelled_clinic.yml
+++ b/models/prod/_cancelled_clinic.yml
@@ -74,7 +74,7 @@ models:
         description: Mobile number of the registered patient
         data_type: character varying
       - name: calculated_age
-        description: Calculated age based on date of birth
+        description: Calculated age based on date of birth and fiscal year end date
         data_type: text
       - name: age_group
         description: Age group classification

--- a/models/prod/_clinic_bay_mgmt.yml
+++ b/models/prod/_clinic_bay_mgmt.yml
@@ -100,7 +100,7 @@ models:
         description: Mobile number of the registered patient
       - name: calculated_age
         data_type: text
-        description: Calculated age based on date of birth
+        description: Calculated age based on date of birth and fiscal year end date
       - name: age_group
         data_type: text
         description: Age group classification

--- a/models/prod/_pathways.yml
+++ b/models/prod/_pathways.yml
@@ -43,7 +43,7 @@ models:
         description: Diagnosis information
       - name: calculated_age
         data_type: text
-        description: Calculated age based on date of birth
+        description: Calculated age based on date of birth and fiscal year end date
       - name: age_group
         data_type: text
         description: Age group classification


### PR DESCRIPTION
The logic for determining calculated_age and age_group is modified in the 'clinic_data' model in the intermediate schema.
The documentation for calculated_age is also updated in the .yml files of the respective downstream models.
This adjustment allows for variations in a child's age across different years, enabling us to observe the number of children in various age groups for a specific year.

We have tested the code and created a PR. 
Please take a look into it.

Thank you.
