### PR TITLE
Branch Exclude dummy records and Add helper column to track new patient registrations

### DIFF
--- a/models/intermediate/_clinic_data.yml
+++ b/models/intermediate/_clinic_data.yml
@@ -179,6 +179,6 @@ models:
       - name: dep_shortened
         data_type: text
         description: Acronym representing a department
-      - name: registration_type
+      - name: reg_type_based_on_current_fy
         data_type: text
         description: Category of the registration type based on ongoing fiscal year

--- a/models/intermediate/_clinic_data.yml
+++ b/models/intermediate/_clinic_data.yml
@@ -179,3 +179,6 @@ models:
       - name: dep_shortened
         data_type: text
         description: Acronym representing a department
+      - name: registration_type
+        data_type: text
+        description: Category of the registration type based on ongoing fiscal year

--- a/models/intermediate/clinic_data.sql
+++ b/models/intermediate/clinic_data.sql
@@ -193,7 +193,6 @@ SELECT
         ),
         2
     )::NUMERIC AS present_age,
-    -- registration_type: New Registration when MRN is 7 digits and its YYMM falls in the fiscal year
     -- registration_type based on CURRENT_DATE fiscal year span (Apr 1 .. Mar 31)
     CASE
         WHEN bcd.mrno IS NULL THEN 'Old Registration'
@@ -212,7 +211,7 @@ SELECT
                  END), 'YYMM')::INT
         THEN 'New Registration'
         ELSE 'Old Registration'
-    END AS registration_type
+    END AS reg_type_based_on_current_fy
 
 FROM Base_Clinic_Data AS bcd
 ),

--- a/models/intermediate/clinic_data.sql
+++ b/models/intermediate/clinic_data.sql
@@ -13,14 +13,17 @@ WITH clinic_data AS (
         -- Cleaned doctor name value by removing titles, salutations and extra spaces
         -- The regex removes common titles like Dr., Miss, Ms., Mr., Mrs., and Mister
         REGEXP_REPLACE(
+            TRIM(
             REGEXP_REPLACE(
-                TRIM(
-                    REGEXP_REPLACE(doctor, '(?i)(^|\s)(dr\.?|miss|ms\.?|mr\.?|mister|mrs\.?)(\s|$)', ' ')
-                ),
-                '\s+', ' '
+                REGEXP_REPLACE(doctor, '(?i)(^|\s)(dr\.?|miss|ms\.?|mr\.?|mister|mrs\.?)(\s|$)', ' ', 'g'),
+                '[^A-Za-z0-9\s]', ' ', 'g'
+            )
             ),
-            '^\s+|\s+$', ''
+            '\s+', ' ',
+            'g'
         )::VARCHAR AS doctor,
+
+
         TO_DATE(consultationrequestdate, 'DD-MON-YY') AS consultation_date,
         REPLACE(appointmenttype,'?', '-') AS consultation_type,
         unit,

--- a/models/intermediate/participant_impact.sql
+++ b/models/intermediate/participant_impact.sql
@@ -77,7 +77,7 @@ SELECT
         WHEN LOWER(brpd."regNonWorkingMonth") = 'none' THEN 0
         WHEN LOWER(brpd."regNonWorkingMonth") LIKE 'greater than %' THEN 
             CAST(
-                REGEXP_REPLACE(LOWER(brpd"regNonWorkingMonth"), '^greater than\s+(\d+).*$', '\1')
+                REGEXP_REPLACE(LOWER(brpd."regNonWorkingMonth"), '^greater than\s+(\d+).*$', '\1')
                 AS INTEGER
             )
         WHEN brpd."regNonWorkingMonth" LIKE '%-%' THEN

--- a/models/intermediate/participant_impact.sql
+++ b/models/intermediate/participant_impact.sql
@@ -74,20 +74,20 @@ LEFT JOIN {{ source('staging_lookup', 'org_mapping') }} org_lookup
 SELECT 
     *,
     CASE
-        WHEN LOWER("regNonWorkingMonth") = 'none' THEN 0
-        WHEN LOWER("regNonWorkingMonth") LIKE 'greater than %' THEN 
+        WHEN LOWER(brpd."regNonWorkingMonth") = 'none' THEN 0
+        WHEN LOWER(brpd."regNonWorkingMonth") LIKE 'greater than %' THEN 
             CAST(
-                REGEXP_REPLACE(LOWER("regNonWorkingMonth"), '^greater than\s+(\d+).*$', '\1')
+                REGEXP_REPLACE(LOWER(brpd"regNonWorkingMonth"), '^greater than\s+(\d+).*$', '\1')
                 AS INTEGER
             )
-        WHEN "regNonWorkingMonth" LIKE '%-%' THEN
+        WHEN brpd."regNonWorkingMonth" LIKE '%-%' THEN
             ROUND(
             (
-                CAST(LTRIM(SPLIT_PART(TRIM("regNonWorkingMonth"), '-', 1), '0') AS INTEGER) +
-                CAST(LTRIM(SPLIT_PART(TRIM("regNonWorkingMonth"), '-', 2), '0') AS INTEGER)
+                CAST(LTRIM(SPLIT_PART(TRIM(brpd."regNonWorkingMonth"), '-', 1), '0') AS INTEGER) +
+                CAST(LTRIM(SPLIT_PART(TRIM(brpd."regNonWorkingMonth"), '-', 2), '0') AS INTEGER)
             ) / 2.0
             )::INTEGER
         ELSE 0
     END::INTEGER AS training_indirect_reach_monthly
-FROM BASE_REG_PARTICIPANT_DATA
+FROM BASE_REG_PARTICIPANT_DATA AS brpd
     

--- a/models/intermediate/participant_impact.sql
+++ b/models/intermediate/participant_impact.sql
@@ -1,7 +1,7 @@
 {{ config(materialized='table') }}
 
 WITH BASE_REG_PARTICIPANT_DATA AS 
-(SELECT
+(SELECT DISTINCT
     "pId" AS pid, 
     city,
     gender AS participant_gender,

--- a/models/intermediate/participant_impact.sql
+++ b/models/intermediate/participant_impact.sql
@@ -1,6 +1,7 @@
 {{ config(materialized='table') }}
 
-SELECT
+WITH BASE_REG_PARTICIPANT_DATA AS 
+(SELECT
     "pId" AS pid, 
     city,
     gender AS participant_gender,
@@ -48,22 +49,6 @@ SELECT
     "secondaryContact" AS secondary_contact,
     "relationWithChild" AS relation_with_child,
     "regNonWorkingMonth" AS working_with_people_devdelay_montly,
-    CASE
-        WHEN LOWER("regNonWorkingMonth") = 'none' THEN 0
-        WHEN LOWER("regNonWorkingMonth") LIKE 'greater than %' THEN 
-            CAST(
-                REGEXP_REPLACE(LOWER("regNonWorkingMonth"), '^greater than\s+(\d+).*$', '\1')
-                AS INTEGER
-            )
-        WHEN "regNonWorkingMonth" LIKE '%-%' THEN
-            ROUND(
-            (
-                CAST(LTRIM(SPLIT_PART(TRIM("regNonWorkingMonth"), '-', 1), '0') AS INTEGER) +
-                CAST(LTRIM(SPLIT_PART(TRIM("regNonWorkingMonth"), '-', 2), '0') AS INTEGER)
-            ) / 2.0
-            )::INTEGER
-        ELSE 0
-    END::INTEGER AS training_indirect_reach_monthly,
     "childBirthDateinfo1" AS child_birth_date_info1,
     "childBirthDateinfo2" AS child_birth_date_info2,
     "childBirthDateinfo3" AS child_birth_date_info3,
@@ -84,3 +69,25 @@ SELECT
 FROM {{ source('source_ummeed_synergy_connect', 'participant_impact') }} pi
 LEFT JOIN {{ source('staging_lookup', 'org_mapping') }} org_lookup
     ON LOWER(TRIM(pi."orgnisationName")) = LOWER(TRIM(org_lookup.organization_name))
+),
+
+SELECT 
+    *,
+    CASE
+        WHEN LOWER("regNonWorkingMonth") = 'none' THEN 0
+        WHEN LOWER("regNonWorkingMonth") LIKE 'greater than %' THEN 
+            CAST(
+                REGEXP_REPLACE(LOWER("regNonWorkingMonth"), '^greater than\s+(\d+).*$', '\1')
+                AS INTEGER
+            )
+        WHEN "regNonWorkingMonth" LIKE '%-%' THEN
+            ROUND(
+            (
+                CAST(LTRIM(SPLIT_PART(TRIM("regNonWorkingMonth"), '-', 1), '0') AS INTEGER) +
+                CAST(LTRIM(SPLIT_PART(TRIM("regNonWorkingMonth"), '-', 2), '0') AS INTEGER)
+            ) / 2.0
+            )::INTEGER
+        ELSE 0
+    END::INTEGER AS training_indirect_reach_monthly
+FROM BASE_REG_PARTICIPANT_DATA
+    

--- a/models/intermediate/participant_impact.sql
+++ b/models/intermediate/participant_impact.sql
@@ -69,7 +69,7 @@ WITH BASE_REG_PARTICIPANT_DATA AS
 FROM {{ source('source_ummeed_synergy_connect', 'participant_impact') }} pi
 LEFT JOIN {{ source('staging_lookup', 'org_mapping') }} org_lookup
     ON LOWER(TRIM(pi."orgnisationName")) = LOWER(TRIM(org_lookup.organization_name))
-),
+)
 
 SELECT 
     *,

--- a/models/intermediate/participant_impact.sql
+++ b/models/intermediate/participant_impact.sql
@@ -74,17 +74,17 @@ LEFT JOIN {{ source('staging_lookup', 'org_mapping') }} org_lookup
 SELECT 
     *,
     CASE
-        WHEN LOWER(brpd."regNonWorkingMonth") = 'none' THEN 0
-        WHEN LOWER(brpd."regNonWorkingMonth") LIKE 'greater than %' THEN 
+        WHEN LOWER(brpd."working_with_people_devdelay_montly") = 'none' THEN 0
+        WHEN LOWER(brpd."working_with_people_devdelay_montly") LIKE 'greater than %' THEN 
             CAST(
-                REGEXP_REPLACE(LOWER(brpd."regNonWorkingMonth"), '^greater than\s+(\d+).*$', '\1')
+                REGEXP_REPLACE(LOWER(brpd."working_with_people_devdelay_montly"), '^greater than\s+(\d+).*$', '\1')
                 AS INTEGER
             )
-        WHEN brpd."regNonWorkingMonth" LIKE '%-%' THEN
+        WHEN brpd."working_with_people_devdelay_montly" LIKE '%-%' THEN
             ROUND(
             (
-                CAST(LTRIM(SPLIT_PART(TRIM(brpd."regNonWorkingMonth"), '-', 1), '0') AS INTEGER) +
-                CAST(LTRIM(SPLIT_PART(TRIM(brpd."regNonWorkingMonth"), '-', 2), '0') AS INTEGER)
+                CAST(LTRIM(SPLIT_PART(TRIM(brpd."working_with_people_devdelay_montly"), '-', 1), '0') AS INTEGER) +
+                CAST(LTRIM(SPLIT_PART(TRIM(brpd."working_with_people_devdelay_montly"), '-', 2), '0') AS INTEGER)
             ) / 2.0
             )::INTEGER
         ELSE 0

--- a/models/prod/_clinic_bay_mgmt.yml
+++ b/models/prod/_clinic_bay_mgmt.yml
@@ -176,6 +176,9 @@ models:
       - name: dep_shortened
         data_type: text
         description: Acronym representing a department
+      - name: reg_type_based_on_current_fy
+        data_type: text
+        description: Category of the registration type based on ongoing fiscal year
       - name: year
         data_tests:
           - not_null

--- a/models/prod/clinic_bay_mgmt.sql
+++ b/models/prod/clinic_bay_mgmt.sql
@@ -54,6 +54,7 @@ SELECT
     consultation_category, 
     dep_consult_category, 
     dep_shortened,
+    registration_type,
     EXTRACT(YEAR FROM consultation_date) AS year,
     -- Calculate Financial Year
     CASE 
@@ -83,6 +84,6 @@ SELECT
 
 FROM {{ ref('clinic_data') }}
 WHERE 
---    TRIM(patient_name) <> 'Dummy Ummeed'
+--  TRIM(patient_name) <> 'Dummy Ummeed'
     TRIM(patient_name) NOT ILIKE '%Dummy%'
     AND consultation_type NOT IN ('Internal Review', 'Phone/Email Query', 'UPPA Fees')

--- a/models/prod/clinic_bay_mgmt.sql
+++ b/models/prod/clinic_bay_mgmt.sql
@@ -54,7 +54,7 @@ SELECT
     consultation_category, 
     dep_consult_category, 
     dep_shortened,
-    registration_type,
+    reg_type_based_on_current_fy,
     EXTRACT(YEAR FROM consultation_date) AS year,
     -- Calculate Financial Year
     CASE 

--- a/models/prod/clinic_bay_mgmt.sql
+++ b/models/prod/clinic_bay_mgmt.sql
@@ -83,5 +83,6 @@ SELECT
 
 FROM {{ ref('clinic_data') }}
 WHERE 
-    TRIM(patient_name) <> 'Dummy Ummeed'
+--    TRIM(patient_name) <> 'Dummy Ummeed'
+    TRIM(patient_name) NOT ILIKE '%Dummy%'
     AND consultation_type NOT IN ('Internal Review', 'Phone/Email Query', 'UPPA Fees')

--- a/models/prod/pathways.sql
+++ b/models/prod/pathways.sql
@@ -44,7 +44,8 @@ WITH cleaned_clinic_data AS (
         END AS quarter
     FROM {{ ref('clinic_data') }}
     WHERE 
-        TRIM(patient_name) <> 'Dummy Ummeed'
+        --TRIM(patient_name) <> 'Dummy Ummeed'
+        TRIM(patient_name) NOT ILIKE '%Dummy%'
         AND consultation_type NOT IN ('Internal Review', 'Phone/Email Query', 'UPPA Fees')
 ),
 


### PR DESCRIPTION
Hello, Good Morning.

Dummy records were found in the 'clinic_bay_mgmt' dataset, so we changed the logic to remove them. 
The helper column called 'reg_type_based_on_current_year' is added to help us track new registrations for the current year.

Additionaly, we trim doctor names before mapping their levels in the mapping table. And DBT code fix is made for the 'registered_participant' model to prevent duplicate records caused by join.

We have tested the code, so could you please take a moment to review it and merge the changes from PR 45? 
Thank you!!!