### PR TITLE
Branch appointment cancellations

### DIFF
--- a/models/intermediate/_appointment_data.yml
+++ b/models/intermediate/_appointment_data.yml
@@ -55,6 +55,9 @@ models:
       - name: event_status
         data_type: text
         description: Status of the event
+      - name: event_status_MandE
+        data_type: text
+        description: Modified event status for monitoring and evaluation purposes to incoroporate rescheduled appointments.
       - name: isprocessed
         data_type: character varying
         description: Indicates if the event has been processed

--- a/models/intermediate/appointment_data.sql
+++ b/models/intermediate/appointment_data.sql
@@ -30,13 +30,19 @@ WITH appointment_data AS(
     NULLIF(department, '')::VARCHAR AS department,
     NULLIF(createddate, '')::DATE AS created_date,
     NULLIF(eventstatus, '') AS event_status,
+    NULLIF(cancelreason, '') AS cancel_reason,
+    -- Helper column: if cancelled due to reschedule mark as RESCHEDULED else keep original status
+    CASE
+        WHEN NULLIF(eventstatus, '') = 'CANCEL' AND NULLIF(cancelreason, '') = 'Appointment Rescheduled' THEN 'RESCHEDULED'
+        ELSE NULLIF(eventstatus, '')
+    END AS event_status_MandE,
     isprocessed::VARCHAR,
     NULLIF(patientname, '') AS patient_name,
     NULLIF(slotendtime, '') AS slot_end_time,
     NULLIF(updateddate, '') AS updated_date,
 
     --Cancellation Logic
-
+    
     -- Extracting the cancel code (First two parts: 'XX - YY')
     CASE 
         WHEN cancelreason LIKE 'PC%' THEN TRIM(SPLIT_PART(cancelreason, '.', 1))
@@ -44,20 +50,32 @@ WITH appointment_data AS(
         WHEN cancelreason LIKE 'OC%' THEN TRIM(SPLIT_PART(cancelreason, '.', 1))
         WHEN cancelreason LIKE 'XC%' THEN TRIM(SPLIT_PART(cancelreason, '.', 1))
         WHEN cancelreason LIKE 'NS%' THEN TRIM(SPLIT_PART(cancelreason, '.', 1))
-        WHEN cancelreason = 'Patient Cancelled 48 hours before appointment' THEN 'PC' 
+        WHEN cancelreason = 'Patient Cancelled 48 hours before appointment' THEN 'PC'
+        WHEN cancelreason = 'Appointment Rescheduled' THEN 'AR'
+        ELSE NULL 
     END AS cancel_code,
 
     -- Identifying who cancelled the appointment (NULL if cancelreason is empty)
-    CASE 
-        WHEN cancelreason IS NULL OR TRIM(cancelreason) = '' THEN NULL
-        WHEN cancelreason LIKE 'UC%' THEN 'Ummeed'
-        WHEN cancelreason LIKE 'PC%' OR cancelreason = 'Patient Cancelled 48 hours before appointment' THEN 'Patient'
-        ELSE 'Other'
+    -- CASE 
+    --     WHEN cancelreason IS NULL OR TRIM(cancelreason) = '' THEN NULL
+    --     WHEN cancelreason LIKE 'UC%' THEN 'Ummeed'
+    --     WHEN cancelreason LIKE 'PC%' OR cancelreason = 'Patient Cancelled 48 hours before appointment' THEN 'Patient'
+    --     ELSE 'Other'
+    -- END AS cancelled_by,
+
+    -- Determine cancelled_by using cancel_code and event_status_MandE
+    CASE
+        WHEN event_status_MandE IN ('CANCEL', 'NO_SHOW') AND cancel_code IS NULL THEN NULL
+        WHEN event_status_MandE IN ('CANCEL', 'NO_SHOW') AND cancel_code LIKE 'PC%' THEN 'Patient Cancelled'
+        WHEN event_status_MandE IN ('CANCEL', 'NO_SHOW') AND cancel_code LIKE 'UC%' THEN 'Ummeed'
+        WHEN event_status_MandE IN ('CANCEL', 'NO_SHOW') THEN 'Other'
+        ELSE NULL
     END AS cancelled_by,
 
     -- Extracting the actual cancellation reason without numbers
     CASE 
         WHEN cancelreason = 'Patient Cancelled 48 hours before appointment' THEN cancelreason
+        WHEN cancelreason = 'Appointment Rescheduled' THEN cancelreason
         WHEN cancelreason IS NULL OR TRIM(cancelreason) = '' THEN NULL
         ELSE TRIM(REGEXP_REPLACE(SPLIT_PART(cancelreason, '- ', 2), '^\d+\.\s*', ''))
     END AS cancellation_reason,

--- a/models/intermediate/appointment_data.sql
+++ b/models/intermediate/appointment_data.sql
@@ -63,15 +63,6 @@ WITH appointment_data AS(
     --     ELSE 'Other'
     -- END AS cancelled_by,
 
-    -- Determine cancelled_by using cancel_code and event_status_MandE
-    CASE
-        WHEN event_status_MandE IN ('CANCEL', 'NO_SHOW') AND cancel_code IS NULL THEN NULL
-        WHEN event_status_MandE IN ('CANCEL', 'NO_SHOW') AND cancel_code LIKE 'PC%' THEN 'Patient Cancelled'
-        WHEN event_status_MandE IN ('CANCEL', 'NO_SHOW') AND cancel_code LIKE 'UC%' THEN 'Ummeed'
-        WHEN event_status_MandE IN ('CANCEL', 'NO_SHOW') THEN 'Other'
-        ELSE NULL
-    END AS cancelled_by,
-
     -- Extracting the actual cancellation reason without numbers
     CASE 
         WHEN cancelreason = 'Patient Cancelled 48 hours before appointment' THEN cancelreason
@@ -85,6 +76,19 @@ WITH appointment_data AS(
     TO_TIMESTAMP(NULLIF(eventvalidto, ''), 'Mon DD, YYYY HH12:MI:SS PM') AS event_valid_to
 
 FROM {{ source('source_ummeed_ict_health', 'appointment_details') }} AS appointment_data
+),
+
+appointment_data_with_cancelled_by AS (
+    SELECT
+        *,
+        CASE
+            WHEN event_status_MandE IN ('CANCEL', 'NO_SHOW') AND cancel_code IS NULL THEN NULL
+            WHEN event_status_MandE IN ('CANCEL', 'NO_SHOW') AND cancel_code LIKE 'PC%' THEN 'Patient Cancelled'
+            WHEN event_status_MandE IN ('CANCEL', 'NO_SHOW') AND cancel_code LIKE 'UC%' THEN 'Ummeed'
+            WHEN event_status_MandE IN ('CANCEL', 'NO_SHOW') THEN 'Other'
+            ELSE NULL
+        END AS cancelled_by
+    FROM appointment_data
 ),
 
 promotions as (
@@ -102,7 +106,7 @@ promotions as (
 SELECT 
     ad.*,
     COALESCE(p.doctor_lvl, 'Not Available') AS doctor_level  -- Mapped from dim_doctor_level_mapping
-FROM appointment_data AS ad
+FROM appointment_data_with_cancelled_by AS ad
 LEFT JOIN promotions AS p
         ON ad.doctor = p.doctor_name 
         AND ad.created_date >= p.promotion_date

--- a/models/prod/_appointment_details.yml
+++ b/models/prod/_appointment_details.yml
@@ -55,6 +55,9 @@ models:
       - name: event_status
         data_type: text
         description: Status of the event
+      - name: event_status_MandE
+        data_type: text
+        description: Modified event status for monitoring and evaluation purposes to incoroporate rescheduled appointments.
       - name: isprocessed
         data_type: numeric
         description: Indicates if the event has been processed

--- a/models/prod/appointment_details.sql
+++ b/models/prod/appointment_details.sql
@@ -17,6 +17,7 @@ SELECT
     department,
     created_date,
     event_status,
+    event_status_MandE,
     isprocessed,
     patient_name,
     slot_end_time,

--- a/models/prod/cancelled_clinic.sql
+++ b/models/prod/cancelled_clinic.sql
@@ -111,8 +111,8 @@ filtered_appointments AS (
 
         -- Appointment-specific fields
         CASE 
-            WHEN LOWER(event_status) = 'cancel' THEN 'Cancel'
-            WHEN LOWER(event_status) = 'no_show' THEN 'No Show'
+            WHEN LOWER(event_status_MandE) = 'cancel' THEN 'Cancel'
+            WHEN LOWER(event_status_MandE) = 'no_show' THEN 'No Show'
             ELSE event_status
         END AS event_status,
         cancel_code,


### PR DESCRIPTION
Hello, Good afternoon.

In the existing DBT logic, appointments with 'cancelreason' = ‘Appointment Rescheduled’ were getting classified under the ‘Other’ category in the 'Cancelled By' column.

With the modified logic, such rescheduled appointments are excluded from the cancelled appointments, ensuring greater accuracy in reporting.

The DBT code has been updated in the following way to improve accuracy in identifying appointment cancellations.
A helper column, 'event_status_mande', has been introduced:when event_status = CANCEL and cancelreason = ‘Appointment Rescheduled’, the value is set to ‘RESCHEDULED’.
'cancelled_by' values are now determined using the combination of 'event_status_mande' and 'cancel_code':
If 'event_status_mande' is CANCEL or NO_SHOW and 'cancel_code' is NULL → NULL
If 'event_status_mande' is CANCEL or NO_SHOW and 'cancel_code'  LIKE ‘PC’ → Patient Cancelled
If 'event_status_mande' is CANCEL or NO_SHOW and 'cancel_code' LIKE ‘UC’ → Ummeed
If 'event_status_mande' is CANCEL or NO_SHOW and 'cancel_code'  has any other value → Other